### PR TITLE
Bug Fix: accomodate super economic fees

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -643,7 +643,7 @@ func (wallet *EthereumWallet) GetFeePerByte(feeLevel wi.FeeLevel) big.Int {
 	switch feeLevel {
 	case wi.NORMAL:
 		ret, _ = big.NewFloat(est.Average * 100000000).Int(nil)
-	case wi.ECONOMIC:
+	case wi.ECONOMIC, wi.SUPER_ECONOMIC:
 		ret, _ = big.NewFloat(est.SafeLow * 100000000).Int(nil)
 	case wi.PRIOIRTY, wi.FEE_BUMP:
 		ret, _ = big.NewFloat(est.Fast * 100000000).Int(nil)


### PR DESCRIPTION
This is a bug fix because right now no one can send Super Economic ETH txs.